### PR TITLE
Renamed module to go-splunk-client

### DIFF
--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -19,8 +19,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/splunk/go-sdk/pkg/authenticators"
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/authenticators"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 func main() {

--- a/examples/roles/main.go
+++ b/examples/roles/main.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/authenticators"
-	"github.com/splunk/go-sdk/pkg/client"
-	"github.com/splunk/go-sdk/pkg/entry"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/authenticators"
+	"github.com/splunk/go-splunk-client/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/entry"
 )
 
 func main() {

--- a/examples/saml_groups/main.go
+++ b/examples/saml_groups/main.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/authenticators"
-	"github.com/splunk/go-sdk/pkg/client"
-	"github.com/splunk/go-sdk/pkg/entry"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/authenticators"
+	"github.com/splunk/go-splunk-client/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/entry"
 )
 
 func main() {

--- a/examples/users/main.go
+++ b/examples/users/main.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/authenticators"
-	"github.com/splunk/go-sdk/pkg/client"
-	"github.com/splunk/go-sdk/pkg/entry"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/authenticators"
+	"github.com/splunk/go-splunk-client/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/entry"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/splunk/go-sdk
+module github.com/splunk/go-splunk-client
 
 go 1.17
 

--- a/pkg/authenticators/authenticator_test_cases.go
+++ b/pkg/authenticators/authenticator_test_cases.go
@@ -18,8 +18,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/splunk/go-sdk/pkg/client"
-	"github.com/splunk/go-sdk/pkg/internal/checks"
+	"github.com/splunk/go-splunk-client/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/internal/checks"
 )
 
 // AuthenticatorTestCase defines a test against a specific Authenticator and Client.

--- a/pkg/authenticators/password.go
+++ b/pkg/authenticators/password.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 // Password defines password authentication to Splunk.

--- a/pkg/authenticators/session_key.go
+++ b/pkg/authenticators/session_key.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 // SessionKey provides authentication to Splunk via a session key.

--- a/pkg/authenticators/session_key_test.go
+++ b/pkg/authenticators/session_key_test.go
@@ -17,7 +17,7 @@ package authenticators
 import (
 	"testing"
 
-	"github.com/splunk/go-sdk/pkg/internal/checks"
+	"github.com/splunk/go-splunk-client/pkg/internal/checks"
 )
 
 func TestSessionKey_AuthenticateRequest(t *testing.T) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/splunk/go-sdk/pkg/internal/paths"
+	"github.com/splunk/go-splunk-client/pkg/internal/paths"
 	"golang.org/x/net/publicsuffix"
 )
 

--- a/pkg/client/entry.go
+++ b/pkg/client/entry.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/splunk/go-sdk/pkg/internal/paths"
+	"github.com/splunk/go-splunk-client/pkg/internal/paths"
 )
 
 // Entry is the interface that describes types that are support Create, Read, Update,

--- a/pkg/client/handle_response.go
+++ b/pkg/client/handle_response.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/splunk/go-sdk/pkg/messages"
+	"github.com/splunk/go-splunk-client/pkg/messages"
 )
 
 // ResponseHandler defines a function that performs an action on an http.Response.

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -14,7 +14,7 @@
 
 package client
 
-import "github.com/splunk/go-sdk/pkg/internal/paths"
+import "github.com/splunk/go-splunk-client/pkg/internal/paths"
 
 // Service is the interface that describes types that constitute a REST API servce.
 // Such types must implement the nsPather interface, and the endpoint method, which

--- a/pkg/entry/role.go
+++ b/pkg/entry/role.go
@@ -15,8 +15,8 @@
 package entry
 
 import (
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 // RoleContent defines the Content for a Role.

--- a/pkg/entry/saml_group.go
+++ b/pkg/entry/saml_group.go
@@ -15,8 +15,8 @@
 package entry
 
 import (
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 // SAMLGroupContent defines the content for a SAMLGroup.

--- a/pkg/entry/user.go
+++ b/pkg/entry/user.go
@@ -15,8 +15,8 @@
 package entry
 
 import (
-	"github.com/splunk/go-sdk/pkg/attributes"
-	"github.com/splunk/go-sdk/pkg/client"
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+	"github.com/splunk/go-splunk-client/pkg/client"
 )
 
 // UserContent defines the content of a User object.


### PR DESCRIPTION
To avoid confusion with officially supported SDKs, and to clarify what this Go module intends to implement, I've renamed the repository to `go-splunk-client` and this PR updates the module name to match it.

This module isn't intended to implement the full offerings of the Enterprise SDKs, such as custom commands and modular inputs, but instead only to act as a client to Splunk.