### PR TITLE
Added Proxy to custom Transport

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -110,6 +110,7 @@ func (c *Client) httpClientPrep() error {
 		c.httpClient = &http.Client{
 			Timeout: timeout,
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: c.TLSInsecureSkipVerify,
 				},


### PR DESCRIPTION
Closes #3

This PR (re-)adds proxy support to the `Client`'s `http.Client.Transport`.

This ended up being incredibly simple, because the `http` package provides `ProxyFromEnvironment`, which can be configured on the existing `Transport` value. This is the effective configuration if `Transport` isn't overridden, so this technically re-adds the enabling of proxies after permitting setting of `InsecureSkipVerify`, which customized `Transport`.

The client won't provide a means to explicitly set a proxy via configuration at this time; it will rely on the standard of using `HTTP_PROXY` environment variables.