### PR TITLE
Added ACL

### DIFF
--- a/examples/savedsearch/main.go
+++ b/examples/savedsearch/main.go
@@ -64,17 +64,32 @@ func main() {
 	if err := c.Read(&newSearch); err != nil {
 		log.Fatalf("unable to read search: %s", err)
 	}
+	var newSearchACL client.ACL
+	if err := c.ReadACL(newSearch, &newSearchACL); err != nil {
+		log.Fatalf("unable to read search acl: %s", err)
+	}
 	fmt.Printf("created search:\n%#v\n", newSearch)
+	fmt.Printf("created search acl:\n%#v\n", newSearchACL)
 
 	// update search
 	newSearch.Content.Actions = attributes.NamedParametersCollection{} // explicitly clear Actions, disabling all
 	if err := c.Update(newSearch); err != nil {
 		log.Fatalf("unable to update search: %s", err)
 	}
+	newSearchACL.Permissions.Write = []string{"admin"}
+	newSearchACL.Owner = attributes.NewExplicit("nobody")
+	newSearchACL.Sharing = client.SharingGlobal
+	if err := c.UpdateACL(newSearch, newSearchACL); err != nil {
+		log.Fatalf("unable to update search acl: %s", err)
+	}
 	if err := c.Read(&newSearch); err != nil {
 		log.Fatalf("unable to read search: %s", err)
 	}
+	if err := c.ReadACL(newSearch, &newSearchACL); err != nil {
+		log.Fatalf("unable to read search acl: %s", err)
+	}
 	fmt.Printf("updated search:\n%#v\n", newSearch)
+	fmt.Printf("updated search acl:\n%#v\n", newSearchACL)
 
 	// delete search
 	if err := c.Delete(newSearch); err != nil {

--- a/pkg/client/acl.go
+++ b/pkg/client/acl.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/splunk/go-splunk-client/pkg/attributes"
+)
+
+// Sharing represents the level of sharing of a Splunk object.
+type Sharing string
+
+const (
+	SharingUndefined Sharing = ""
+	SharingGlobal    Sharing = "global"
+	SharingUser      Sharing = "user"
+	SharingApp       Sharing = "app"
+)
+
+// validate returns an error if Sharing is a value other than the predefined Sharing constants.
+func (sharing Sharing) validate() error {
+	switch sharing {
+	default:
+		return wrapError(ErrorSharing, nil, "client: invalid Sharing value %q", sharing)
+	case SharingUndefined, SharingGlobal, SharingUser, SharingApp:
+		return nil
+	}
+}
+
+// MarshalJSON implements custom marshaling.
+func (sharing Sharing) MarshalJSON() ([]byte, error) {
+	if err := sharing.validate(); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(string(sharing))
+}
+
+// Permissions represents the read/write permissions of a Splunk object.
+type Permissions struct {
+	Read  []string `json:"read"  values:"read,omitzero,fillempty"`
+	Write []string `json:"write" values:"write,omitzero,fillempty"`
+}
+
+// ACL represents the ACL of a Splunk object.
+type ACL struct {
+	Permissions Permissions                 `json:"perms"   values:"perms"`
+	Owner       attributes.Explicit[string] `json:"owner"   values:"owner,omitzero"`
+	Sharing     Sharing                     `json:"sharing" values:"sharing,omitzero"`
+}

--- a/pkg/client/build_request.go
+++ b/pkg/client/build_request.go
@@ -152,6 +152,21 @@ func BuildRequestEntryURL(c *Client, entry interface{}) RequestBuilder {
 	}
 }
 
+// BuildRequestEntryACLURL returns a RequestBuilder that sets the URL to the ACL URL
+// for a given Entry.
+func BuildRequestEntryACLURL(c *Client, entry interface{}, acl ACL) RequestBuilder {
+	return func(r *http.Request) error {
+		u, err := c.EntryACLURL(entry)
+		if err != nil {
+			return err
+		}
+
+		r.URL = u
+
+		return nil
+	}
+}
+
 // BuildRequestAuthenticate returns a RequestBuilder that authenticates a request for a given Client.
 func BuildRequestAuthenticate(c *Client) RequestBuilder {
 	return func(r *http.Request) error {

--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -77,6 +77,9 @@ const (
 
 	// ErrorID indicates an error was encountered related to an object's ID.
 	ErrorID
+
+	// ErrorSharing indicates an error was encountered related to a Sharing value.
+	ErrorSharing
 )
 
 // Error represents an encountered error. It adheres to the "error" interface,


### PR DESCRIPTION
This PR adds the `ACL` type and `ReadACL` and `UpdateACL` methods.

`ACL`s are not members of the `entry` types, as they are not managed directly by the same endpoints. Instead `ReadACL` and `UpdateACL` have `entry` and `ACL` parameters. This decision was based on these points:

* not all entry types have ACLs
* operating on an ACL object in an entry type would require either making it embedded/anonymous (which we've actively avoided due to other issues) or reflection.

Considering the added complexity that would be required to have ACLs on each type that can have them, it doesn't seem worth it, at least at this time, to implement it. The work done in this PR would likely need to have been done regardless, with the additional functionality building off of it, so this work is valid even if at some point it is decided that entry types should have ACL fields.